### PR TITLE
Adding env command to export environment keys

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,7 +15,8 @@ jobs:
         run: |
           rustup install nightly
           rustup override set nightly
-          rustup component add clippy rustfmt
+          rustup component add clippy llvm-tools-preview rustfmt
+          cargo install cargo-llvm-cov
 
       - name: Toolchain info
         run: |
@@ -31,7 +32,8 @@ jobs:
       - name: Test
         run: |
           cargo check
-          cargo test --all
+          cargo llvm-cov
+          cargo test --doc
 
       - name: Build
         run: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,6 +21,7 @@ nacl = "0.5"
 rand = { version = "0.8", features = ["std"] }
 regex = "1.9"
 serde_json = { version = "1.0", features = ["preserve_order"] }
+shell-escape = "0.1"
 
 [dev-dependencies]
 assert_cmd = "2.0"

--- a/README.md
+++ b/README.md
@@ -32,6 +32,7 @@ filing an issue.
 ### Additions to EJSON
 
 * A `--strip-key` flag on `decrypt` which will remove `_public_key` from the result.
+* `env` command which will export all keys under the top-level `environment` key.
 
 ## Usage
 
@@ -48,11 +49,23 @@ Commands:
   encrypt  Encrypt one or more EJSON files
   decrypt  Decrypt an EJSON file
   keygen   Generate a new EJSON key pair
+  env      Export the all scalar values under the "environment" key
   help     Print this message or the help of the given subcommand(s)
 
 Options:
   -h, --help     Print help
   -V, --version  Print version
+```
+
+To export all environment values in the environment key, run `eval $(rejson env secrets.ejson)`.
+
+```ignore
+{
+  "_public_key": "...",
+  "environment": {
+    "SOME_KEY": "SOME_VALUE"
+  }
+}
 ```
 
 ### Docker

--- a/tests/export.rs
+++ b/tests/export.rs
@@ -1,0 +1,67 @@
+use std::fs;
+
+use anyhow::Result;
+use assert_cmd::Command;
+
+const PUB_KEY: &str = "b595226c62427adbfc4a809cd7577488a6d402b2f930e1d603164ae3191a616e";
+const PRIV_KEY: &str = "88649a9e83f8f1984ad35ac8e8e86529aab518572c0341f46d1e0bc97f676f2b";
+
+#[test]
+fn export() -> Result<()> {
+    let key_file = assert_fs::NamedTempFile::new(PUB_KEY)?;
+    fs::write(key_file.path(), PRIV_KEY)?;
+
+    let file = assert_fs::NamedTempFile::new("secrets.ejson")?;
+    fs::write(
+        file.path(),
+        serde_json::json!({
+            "_public_key": PUB_KEY,
+            "environment": {
+                "some":"EJ[1:l6yw664nxaddSXGiWUZfuVeoUSpTFHzqAyCpfF8Awxc=:xOfucLDkACGlPCyJ6QViggEidVswUlsH:B/f3DJMkdZHF+Wu9F6XUFwuTmxyfBA==]"
+            }
+        })
+        .to_string(),
+    )?;
+
+    Command::cargo_bin("rejson")?
+        .arg("env")
+        .arg(file.path())
+        .arg("--keydir")
+        .arg(key_file.parent().unwrap())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains("export some=secret"));
+
+    Ok(())
+}
+
+#[test]
+fn export_shell_escape() -> Result<()> {
+    let key_file = assert_fs::NamedTempFile::new(PUB_KEY)?;
+    fs::write(key_file.path(), PRIV_KEY)?;
+
+    let file = assert_fs::NamedTempFile::new("secrets.ejson")?;
+    fs::write(
+        file.path(),
+        serde_json::json!({
+            "_public_key": PUB_KEY,
+            "environment": {
+                "some": "EJ[1:1an1ebJDsGEnhGd94K9XonLvMokD4HSiKT5xgagdlEw=:KLlxcpkMMUCk4X5aZpNGCG6jUqJoytU2:lAk6EmtaEovXAgw9LuNJYZCYk3DR5ri0KjP3tfNo87U2bguF44qW8hL0BXfuM5olFz0=]"
+            }
+        })
+        .to_string(),
+    )?;
+
+    Command::cargo_bin("rejson")?
+        .arg("env")
+        .arg(file.path())
+        .arg("--keydir")
+        .arg(key_file.parent().unwrap())
+        .assert()
+        .success()
+        .stdout(predicates::str::contains(
+            "export some=\'Some thing with %$# symbols like \\\'",
+        ));
+
+    Ok(())
+}


### PR DESCRIPTION
Adding `env` to handle exporting keys defined in the _environment_ key into the environment. The command doesn't pollute the environment directly, rather it writes out export statements, which can be eval'ed, redirected to a file, or whatever.

This is effectively the equivalent of [ejson2env].

[ejson2env]: https://github.com/Shopify/ejson2env