### PR TITLE
Use stable toolchain

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,8 +14,8 @@ jobs:
       - name: Update local toolchain
         run: |
           rustup install nightly
-          rustup override set nightly
-          rustup component add clippy llvm-tools-preview rustfmt
+          rustup component add clippy llvm-tools-preview
+          rustup component add rustfmt --toolchain nightly-x86_64-unknown-linux-gnu
           cargo install cargo-llvm-cov
 
       - name: Toolchain info
@@ -26,7 +26,7 @@ jobs:
 
       - name: Lint
         run: |
-          cargo fmt -- --check
+          cargo +nightly fmt -- --check
           cargo clippy -- -D warnings
 
       - name: Test

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -13,7 +13,7 @@ jobs:
       # Publish crate to crates.io
       - uses: actions-rs/toolchain@v1
         with:
-          toolchain: nightly
+          toolchain: stable
           override: true
       - uses: katyo/publish-crates@v2
         with:

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ edition = "2021"
 homepage = "https://github.com/pseudomuto/rejson"
 license = "MIT"
 repository = "https://github.com/pseudomuto/rejson"
+rust-version = "1.70.0"
 
 [[bin]]
 name = "rejson"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # Stage 1: Build the binary
-FROM rustlang/rust:nightly-alpine as build
-RUN apk --update --no-cache add ca-certificates=20230506-r0 musl-dev=1.2.3-r5
+FROM rust:alpine3.18 as build
+RUN apk --update --no-cache add ca-certificates=20230506-r0 musl-dev=1.2.4-r1
 WORKDIR /app
 COPY Cargo.toml README.md ./
 COPY src/ ./src/

--- a/build/pre-commit
+++ b/build/pre-commit
@@ -3,7 +3,7 @@ set -euo pipefail
 
 main() {
   echo "Running cargo fmt to check for style issues..."
-  local diff=$(cargo fmt -- --check)
+  local diff=$(cargo +nightly fmt -- --check)
   local result=$?
 
   if [[ ${result} -ne 0 ]]; then

--- a/src/json.rs
+++ b/src/json.rs
@@ -8,11 +8,6 @@ use crate::crypto::Key;
 const PK_KEY: &str = "_public_key";
 const IGNORE_PREFIX: &str = "_";
 
-/// A trait alias for Fn(String) -> Result<String>.
-///
-/// Transform describes a function used to do transform an eligible value from an EJSON document.
-pub trait Transform = Fn(String) -> Result<String>;
-
 #[derive(Debug)]
 pub struct SecretsFile {
     value: Value,
@@ -40,7 +35,7 @@ impl SecretsFile {
     /// new value to be used in it's place.
     ///
     /// This function transforms the values in place by mutating the underlying structure.
-    pub fn transform<F: Transform>(&mut self, transformer: F) -> Result<()> {
+    pub fn transform<F: Fn(String) -> Result<String>>(&mut self, transformer: F) -> Result<()> {
         self.value
             .as_object_mut()
             .unwrap()
@@ -93,7 +88,7 @@ impl FromStr for SecretsFile {
     }
 }
 
-fn transform<F: Transform>(key: &str, value: &mut Value, tfn: &F) -> Result<()> {
+fn transform<F: Fn(String) -> Result<String>>(key: &str, value: &mut Value, tfn: &F) -> Result<()> {
     match value {
         Value::String(v) => {
             // Only interested in string values who's keys do not start with an underscore as


### PR DESCRIPTION
Initially I had set this up using nightly because of some nicer format options and the trait aliases feature. I don't think it's worth being off stable for a trait alias and fmt can be run using `cargo +nightly fmt ...` so I've migrated to stable and updated the codebase as necessary.