### PR TITLE
Add kube-secrets command for generating secrets manifests

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ filing an issue.
 
 * A `--strip-key` flag on `decrypt` which will remove `_public_key` from the result.
 * `env` command which will export all keys under the top-level `environment` key.
+* `kube-secrets` command which will output K8s secret manifests for values under the `kubernetes` key.
 
 ## Usage
 

--- a/examples/data/secrets.ejson
+++ b/examples/data/secrets.ejson
@@ -4,5 +4,18 @@
   "sub": {
     "key": "EJ[1:kzoS8R+Pg09zJm20V4NgUkzaYW1qIkeZjCUZWNzhL3k=:fi8pYBHJEafrvetiL7CxQ8LDCTgW7Lom:Je+pTscfv61s7b2R6w79tgcebQt5]",
     "namespaced.key": "EJ[1:kzoS8R+Pg09zJm20V4NgUkzaYW1qIkeZjCUZWNzhL3k=:fpJwQdu3FNuBZJs2PkN7Yt0Pa32YBhTd:T3NcctMJ6H/LRyXmB1f9D2LEDFoPiB+J]"
+  },
+  "environment": {
+    "REJSON_TEST": 1,
+    "REJSON_FILE": "EJ[1:UYgZqtd7y5Tyj+saZABHMJynPAPkMbq+UMgFkM9eqTI=:U+rQhe6pH2KbeY35Pxck+2veuS7gef6a:oB1A9a3xU2tXdYgSh6+HjD9mvo1QYqkTgFvMz0M=]"
+  },
+  "kubernetes": {
+    "database": {
+      "DATABASE_URL": "EJ[1:UYgZqtd7y5Tyj+saZABHMJynPAPkMbq+UMgFkM9eqTI=:aDcq9zK85gjvrqtPY7uJcZXAxCY5rDdh:02tI5wa1BkrOvrCFlnmT/IJpZdsfzSzVW9O5]",
+      "READ_ONLY_DATABASE_URL": "EJ[1:UYgZqtd7y5Tyj+saZABHMJynPAPkMbq+UMgFkM9eqTI=:aLbU7t3qwoOvJSjhw2qIfMANgPVnTCDj:8wiX/UAHSAEUR6WoQIC0xg2DN90jYBKphZiI]"
+    },
+    "secret": {
+      "creds.json": "EJ[1:UYgZqtd7y5Tyj+saZABHMJynPAPkMbq+UMgFkM9eqTI=:kqckQyXQXoOZrYRscZlBwkiQ4JPUBQdJ:+7n1/2x/4I1AC5JGVF/RELD7bkZZjj1hDb3YQVdX]"
+    }
   }
 }

--- a/src/kube.rs
+++ b/src/kube.rs
@@ -1,0 +1,85 @@
+use core::fmt;
+use std::collections::{BTreeMap, HashMap};
+
+use base64::Engine;
+
+const KEY_DELIMITER: &str = ".";
+
+/// A wrapper around a map of dot-delimited keys and values that can be converted into a Kubernetes
+/// manifest of secrets.
+pub struct SecretsManifest<'a> {
+    inner: HashMap<&'a str, HashMap<&'a str, &'a str>>,
+}
+
+impl<'a> SecretsManifest<'a> {
+    pub fn new(from: HashMap<&'a str, &'a str>) -> Self {
+        // Convert the delimited keys and values into a HashMap of secret name => <Key, Value>.
+        //
+        // NB: Converts to BTreeMap after filtering so values are sorted by key.
+        let resources = from
+            .into_iter()
+            .map(|(k, v)| (k, v))
+            .collect::<BTreeMap<&str, &str>>()
+            .iter()
+            .fold(HashMap::new(), |mut map, (k, v)| {
+                // secret.key => name = secret, key = key
+                // secret.[file.ext] => name = secret, key = file.ext
+                let name = &k[..k.find(KEY_DELIMITER).unwrap()];
+                let key = &k[k.find(KEY_DELIMITER).unwrap() + 1..];
+
+                // Update values (creating if necessary).
+                let values: &mut HashMap<&str, &str> = map.entry(name).or_default();
+                values.insert(key.trim_matches(&['[', ']'] as &[_]), v);
+
+                map
+            });
+
+        Self { inner: resources }
+    }
+}
+
+impl fmt::Display for SecretsManifest<'_> {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let b64 = base64::engine::general_purpose::STANDARD;
+
+        self.inner.iter().try_for_each(|(k, data)| {
+            writeln!(f, "---")?;
+            writeln!(f, "api: v1")?;
+            writeln!(f, "kind: Secret")?;
+            writeln!(f, "metadata:")?;
+            writeln!(f, "  name: {}", k)?;
+            writeln!(f, "data:")?;
+
+            data.iter()
+                .try_for_each(|(k, v)| writeln!(f, "  {}: {}", k, b64.encode(v)))
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn basic_secrets() {
+        let secrets = HashMap::from([
+            ("database.READ_ONLY_DATABASE_URL", "pgsql://ro_db_url"),
+            ("credentials.path", "/some/path/file.ext"),
+            ("database.DATABASE_URL", "pgsql://db_url"),
+        ]);
+
+        let exp = HashMap::from([
+            (
+                "database",
+                HashMap::from([
+                    ("DATABASE_URL", "pgsql://db_url"),
+                    ("READ_ONLY_DATABASE_URL", "pgsql://ro_db_url"),
+                ]),
+            ),
+            ("credentials", HashMap::from([("path", "/some/path/file.ext")])),
+        ]);
+
+        let manifest = SecretsManifest::new(secrets);
+        assert_eq!(exp, manifest.inner);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,6 +2,7 @@
 
 mod crypto;
 mod json;
+mod kube;
 mod map;
 
 use std::path::Path;
@@ -9,6 +10,7 @@ use std::path::Path;
 use anyhow::Result;
 pub use crypto::{Key, KeyPair};
 pub use json::SecretsFile;
+pub use kube::SecretsManifest;
 pub use map::SecretsMap;
 
 const NEW_LINE: &str = "\n";


### PR DESCRIPTION
Adding a new command that will extract all (nested) values under the top-level `kubernetes` key and print out a Kubernetes manifest for them.

**Example**

```json
{
    "_public_key": "...",
    "kubernetes": {
      "database": {
        "DATABASE_URL": "pgsql://db_conn",
        "READ_ONLY_DATABASE_URL": "pgsql://ro_db_conn"
      },
      "secret": {
        "creds.json": "shh"
      }
    }
}
```

Running `rejson kube-secrets <file>` would yield something like this:

```yaml
---
api: v1
kind: Secret
metadata:
  name: secret
data:
  creds.json: c29tZSBKU09OIHRleHQ=
---
api: v1
kind: Secret
metadata:
  name: database
data:
  READ_ONLY_DATABASE_URL: cGdzcWw6Ly8uLi4=
  DATABASE_URL: cGdzcWw6Ly8uLi4=
```