### PR TITLE
Set default for keydir

### DIFF
--- a/src/bin/rejson.rs
+++ b/src/bin/rejson.rs
@@ -211,7 +211,7 @@ fn load_private_key(secrets_file: &SecretsFile, keydir: Option<String>, key_from
                 std::io::stdin().read_line(&mut buffer)?;
                 buffer.trim().parse()?
             } else {
-                return Err(anyhow::anyhow!("Either --keydir or --key-from-std must be supplied"));
+                rejson::load_private_key(secrets_file, "/opt/ejson/keys")?
             }
         }
     };


### PR DESCRIPTION
EJSON defaults the keydir to /opt/ejson/keys when not supplied via another means. This wasn't done here and since we're trying to be a drop in replacement, I've updated the code to use that default as well.