### PR TITLE
[kube-secrets]: Add Support for Namespaces

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -2,15 +2,15 @@ name: CI
 
 on:
   push:
-    branches: [ main ]
+    branches: [main]
   pull_request:
-    branches: [ main ]
+    branches: [main]
 
 jobs:
   test:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
       - name: Update local toolchain
         run: |
           rustup install nightly

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,7 +8,7 @@ edition = "2021"
 homepage = "https://github.com/pseudomuto/rejson"
 license = "MIT"
 repository = "https://github.com/pseudomuto/rejson"
-rust-version = "1.70.0"
+rust-version = "1.83.0"
 
 [[bin]]
 name = "rejson"
@@ -25,6 +25,6 @@ serde_json = { version = "1.0", features = ["preserve_order"] }
 shell-escape = "0.1"
 
 [dev-dependencies]
-assert_cmd = "2.0"
-assert_fs = "1.0.13"
-predicates = "3.0.3"
+assert_cmd = "2.0.16"
+assert_fs = "1.1.2"
+predicates = "3.1.3"

--- a/README.md
+++ b/README.md
@@ -10,8 +10,9 @@
  collected in a JSON file, in which all the string values are encrypted. Public keys are embedded in the file, and
  the decrypter looks up the corresponding private key from its local filesystem.
 
-> This is a rust port of [EJSON] with a few extra bells and whistles. Full credit should go to the team that made EJSON. No
-innovation here other than needing Rust bindings and wanting a few extra features I'm not sure belonged upstream.
+> This is a rust port of [EJSON] with a few extra bells and whistles. Full credit should go to the team that made
+> EJSON. No innovation here other than needing Rust bindings and wanting a few extra features I'm not sure belonged
+> upstream.
 
 [public key]: http://en.wikipedia.org/wiki/Public-key_cryptography
 [elliptic curve]: http://en.wikipedia.org/wiki/Elliptic_curve_cryptography
@@ -35,7 +36,7 @@ curl -fsSL https://github.com/pseudomuto/rejson/releases/download/v0.2.0/rejson_
 `cargo install rejson`
 
 Since this is a drop-in replacement for `ejson` you can add `alias ejson="rejson"` if you like. The expectation is that
-this is 100% compatible with `ejson` and it only additive. If that's not the case, it's a bug, and I'd appreciate you 
+this is 100% compatible with `ejson` and it only additive. If that's not the case, it's a bug, and I'd appreciate you
 filing an issue.
 
 ### Additions to EJSON
@@ -100,7 +101,7 @@ docker run --rm -it \
   rejson decrypt /files/secrets.ejson
 ```
 
-### Code 
+### Code
 
 ```rust
 use std::fs;
@@ -121,6 +122,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     Ok(())
 }
 ```
+
 See the [_examples_](examples/) directory for more.
 
 ## Development
@@ -128,7 +130,7 @@ See the [_examples_](examples/) directory for more.
 ### Local Setup
 
 * Make sure you have the nightly toolchain (used for rustfmt only)
-* Add pre-commit to avoid committing malformatted code 
+* Add pre-commit to avoid committing malformatted code
   
 ```ignore
 ln -sf ../../build/pre-commit .git/hooks/pre-commit
@@ -150,6 +152,5 @@ attached binaries, etc.
 goreleaser release --clean
 ```
 
-> Yes, I've hacked goreleaser into thinking this is a go project so I can leverage it for running cross, publishing docker
-images, and setting up GitHub releases.
-
+> Yes, I've hacked goreleaser into thinking this is a go project so I can leverage it for running cross, publishing
+> docker images, and setting up GitHub releases.

--- a/src/kube.rs
+++ b/src/kube.rs
@@ -4,6 +4,7 @@ use std::collections::{BTreeMap, HashMap};
 use base64::Engine;
 
 const KEY_DELIMITER: &str = ".";
+const NAMESPACE_KEY: &str = "_namespace";
 
 /// A wrapper around a map of dot-delimited keys and values that can be converted into a Kubernetes
 /// manifest of secrets.
@@ -16,23 +17,22 @@ impl<'a> SecretsManifest<'a> {
         // Convert the delimited keys and values into a HashMap of secret name => <Key, Value>.
         //
         // NB: Converts to BTreeMap after filtering so values are sorted by key.
-        let resources = from
-            .into_iter()
-            .map(|(k, v)| (k, v))
-            .collect::<BTreeMap<&str, &str>>()
-            .iter()
-            .fold(BTreeMap::new(), |mut map, (k, v)| {
-                // secret.key => name = secret, key = key
-                // secret.[file.ext] => name = secret, key = file.ext
-                let name = &k[..k.find(KEY_DELIMITER).unwrap()];
-                let key = &k[k.find(KEY_DELIMITER).unwrap() + 1..];
+        let resources =
+            from.into_iter()
+                .collect::<BTreeMap<&str, &str>>()
+                .iter()
+                .fold(BTreeMap::new(), |mut map, (k, v)| {
+                    // secret.key => name = secret, key = key
+                    // secret.[file.ext] => name = secret, key = file.ext
+                    let name = &k[..k.find(KEY_DELIMITER).unwrap()];
+                    let key = &k[k.find(KEY_DELIMITER).unwrap() + 1..];
 
-                // Update values (creating if necessary).
-                let values: &mut BTreeMap<&str, &str> = map.entry(name).or_default();
-                values.insert(key.trim_matches(&['[', ']'] as &[_]), v);
+                    // Update values (creating if necessary).
+                    let values: &mut BTreeMap<&str, &str> = map.entry(name).or_default();
+                    values.insert(key.trim_matches(&['[', ']'] as &[_]), v);
 
-                map
-            });
+                    map
+                });
 
         Self { inner: resources }
     }
@@ -48,9 +48,14 @@ impl fmt::Display for SecretsManifest<'_> {
             writeln!(f, "kind: Secret")?;
             writeln!(f, "metadata:")?;
             writeln!(f, "  name: {}", k)?;
+
+            if let Some(ns) = data.get(NAMESPACE_KEY) {
+                writeln!(f, "  namespace: {}", ns)?;
+            }
             writeln!(f, "data:")?;
 
             data.iter()
+                .filter(|&(k, _)| k != &NAMESPACE_KEY)
                 .try_for_each(|(k, v)| writeln!(f, "  {}: {}", k, b64.encode(v)))
         })
     }
@@ -65,11 +70,15 @@ mod tests {
         let secrets = HashMap::from([
             ("database.READ_ONLY_DATABASE_URL", "pgsql://ro_db_url"),
             ("credentials.path", "/some/path/file.ext"),
+            ("credentials._namespace", "testing"),
             ("database.DATABASE_URL", "pgsql://db_url"),
         ]);
 
         let exp = BTreeMap::from([
-            ("credentials", BTreeMap::from([("path", "/some/path/file.ext")])),
+            (
+                "credentials",
+                BTreeMap::from([("_namespace", "testing"), ("path", "/some/path/file.ext")]),
+            ),
             (
                 "database",
                 BTreeMap::from([

--- a/tests/kube_secrets.rs
+++ b/tests/kube_secrets.rs
@@ -1,6 +1,7 @@
+use std::fs;
+
 use anyhow::Result;
 use assert_cmd::Command;
-use std::fs;
 
 const PUB_KEY: &str = "b595226c62427adbfc4a809cd7577488a6d402b2f930e1d603164ae3191a616e";
 const PRIV_KEY: &str = "88649a9e83f8f1984ad35ac8e8e86529aab518572c0341f46d1e0bc97f676f2b";
@@ -21,6 +22,7 @@ fn kube_secrets() -> Result<()> {
                     "password": "EJ[1:t33Bwgtq7Zghz1P0D+8ZMiSypiQye4q9DWLuxaOrLEU=:MrpO2Q3ByLTTZCdDXhNwowZvRuVg7c63:lEwnFAwPtrNXb/IKwqXej9V8MjumSSP5Rg==]"
                 },
                 "database": {
+                    "_namespace": "testing",
                     "DATABASE_URL": "EJ[1:t33Bwgtq7Zghz1P0D+8ZMiSypiQye4q9DWLuxaOrLEU=:0w+6gl3gXIOQohjqZnmih8ZLWPVffurJ:7U6ZEcttjrkS5sA73T/y/hESIaoxJUA320XqBoFWvw==]"
                 }
             }
@@ -41,6 +43,7 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: database
+  namespace: testing
 data:
   DATABASE_URL: cGdzcWw6Ly9zb21lLWRi"#;
 


### PR DESCRIPTION
Currently, running `rejson kube-secrets` will generate a secrets manifest for any dictionaries defined under the `kubernetes` key. This has been useful when using secrets for Helm charts for example. The CI server decrypts the manifest into the templates directory before running `helm upgrade`.

However, there are times when we don't necessarily want the secrets to be created in the release namespace. For example, if we have a chart with subcharts, each deploying to their own respective namespaces.

To make this scenario easier, I've added the option to specify a namespace per secret.

```json
{
  "_public_key": " ... ",
  "kubernetes": {
    "my-secret": {
      "value": "EJ[1..."
    },
    "my-namespaced-secret": {
      "_namespace": "custom-ns",
      "value": "EJ[1..."
    }
  }
}
```

Running `rejson kube-secrets` on this file produces the following YAML. Note that only one of the secrets has a namespace defined.

```yaml
apiVersion: v1
kind: Secret
metadata:
  name: my-secret
data:
  value: BASE64_ENCODED_PLAINTEXT
---
apiVersion: v1
kind: Secret
metadata:
  name: my-namespaced-secret
  namespace: custom-ns
data:
  value: BASE64_ENCODED_PLAINTEXT
```