### PR TITLE
Add PowerPC64 Little Endian as cross-compilation target

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -7,6 +7,7 @@ builds:
       - linux_amd64
       - linux_amd64_v2
       - linux_arm64
+      - linux_ppc64le_v1
     hooks:
       post:
         - cmd: sh build/cross {{.Target}}

--- a/build/cross
+++ b/build/cross
@@ -17,6 +17,9 @@ main() {
   linux_arm64_v8.0)
     build_arch "aarch64-unknown-linux-gnu" "rejson_${1}"
     ;;
+  linux_ppc64le_v1)
+    build_arch "powerpc64le-unknown-linux-gnu" "rejson_${1}"
+    ;;
   *)
     echo "${1} not supported"
     ;;


### PR DESCRIPTION
Great thanks for porting the software to Rust. I would like to let you know that software can be compiled natively on PowerPC64 Little Endian (any machine that runs IBM POWER8 or newer). FYI the POWER platform is still alive and going strong, in facts IBM has just announced POWER11 CPU. It would be great if you could add PPC64LE as release target.

P/S: I am using Raptor Computing System Blackbird workstation (running POWER9 CPU)